### PR TITLE
fixed lecture link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Link-Cut Tree implementation in Rust
 
-This repository contains a Rust implementation of the amortized logarithmic link-cut tree data structure as described in [this lecture](https://courses.csail.mit.edu/6.851/spring14/scribe/L19.pdf).
+This repository contains a Rust implementation of the amortized logarithmic link-cut tree data structure as described in [this lecture](https://courses.csail.mit.edu/6.851/spring21/lectures/L19).
 It currently supports `link`, `cut`, and `find_root` operations; see [`src/link_cut_tree.rs`](src/link_cut_tree.rs) for the API.
 Path aggregation (and better documentation) are still to-do items.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Link-Cut Tree implementation in Rust
 
-This repository contains a Rust implementation of the amortized logarithmic link-cut tree data structure as described in [this lecture](http://courses.csail.mit.edu/6.851/spring21/lectures/L19.htm).
+This repository contains a Rust implementation of the amortized logarithmic link-cut tree data structure as described in [this lecture](https://courses.csail.mit.edu/6.851/spring14/scribe/L19.pdf).
 It currently supports `link`, `cut`, and `find_root` operations; see [`src/link_cut_tree.rs`](src/link_cut_tree.rs) for the API.
 Path aggregation (and better documentation) are still to-do items.


### PR DESCRIPTION
The given lecture link is broken. I replaced it with one I found online which seemed to be from the same course, but many years older. I doubt a lecture about Link-cut Trees will have significantly changed over the last 10 years.